### PR TITLE
[BugFix]ims286830 http https 통신 서비스

### DIFF
--- a/install/onprem/hyperdata/hyperdata/templates/external-hd.yaml
+++ b/install/onprem/hyperdata/hyperdata/templates/external-hd.yaml
@@ -1,0 +1,7 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: hyperdata-external-hd
+spec:
+  type: ExternalName
+  externalName: {{ .Values.customAddon.externalHost }}

--- a/install/onprem/hyperdata/hyperdata/templates/ingress-hd.yaml
+++ b/install/onprem/hyperdata/hyperdata/templates/ingress-hd.yaml
@@ -30,3 +30,9 @@ spec:
          backend:
            serviceName: hyperdata-svc-hd
            servicePort: 8081
+   -  http:
+       paths:
+         - path: {{ .Values.customAddon.path }}
+           backend:
+             serviceName: hyperdata-external-hd
+             servicePort: {{ .Values.customAddon.externalPort }}

--- a/install/onprem/hyperdata/hyperdata/values.yaml
+++ b/install/onprem/hyperdata/hyperdata/values.yaml
@@ -49,7 +49,10 @@ customLogo:
 
 customAddon:
   enabled: false
-  url: 
+  url: https://192.168.179.40:8080/java
+  path: /java
+  externalHost: 192.168.173.48
+  externalPort: 8090
 
 sqlEditor:
   enabled: false


### PR DESCRIPTION
https 인 hyperdata 환경에서 http인 ibk 포탈 url을 연결하기 위한 조치입니다.

새로 생긴 변수의 가이드는 아래와 같습니다.

enable은 용도 그대로
url : FE에서 위젯 호출시 호출하는 주소
path: 외부 서버 url
externalHost: 외부 서버 주소
externalPort: 이부 서버 포트

ex) 
예를 들어 HyperData가 1.1.1.1:8080 이고
위젯 호출하는 외부 서버가 9.9.9.9:7000/widget일 경우

enabled: true
url: https://1.1.1.1:8080/widget
path: /widget
externalHost: 9.9.9.9
externalPort: 7000