### PR TITLE
[BugFix]ims286830 https환경에서 http url 적용위한 서비스생성

### DIFF
--- a/install/onprem/hyperdata/README.md
+++ b/install/onprem/hyperdata/README.md
@@ -45,12 +45,31 @@
     --set customAddon.enabled=true
     ```
 
-    1.4 custom addon 사용 사용 시
+    1.4 custom addon 사용 사용 시  
     ```
     helm install -n hyperdata hyperdata hyperdata \ 
     --set customAddon.enabled=true
-    --set customAddon.url=${ADDON_URL}
+    --set customAddon.url=${call_Dir}
+    --set customAddon.path=${external_path}
+    --set customAddon.externalHost=${external_host}
+    --set customAddon.externalPort=${external_port}
     ```
+   enable : custom addon 기능의 사용 여부  
+   url : FE에서 위젯 호출시 호출하는 주소  
+   path: 외부 서버 url  
+   externalHost: 외부 서버 주소  
+   externalPort: 외부 서버 포트     
+   ============================  
+   ex) 예를 들어 HyperData가 1.1.1.1:8080 이고  
+   위젯 호출하는 외부 서버가 9.9.9.9:7000/widget일 경우
+
+   enabled: true  
+   url: https://1.1.1.1:8080/widget  
+   path: /widget  
+   externalHost: 9.9.9.9  
+   externalPort: 7000  
+   입니다.  
+   ============================
 
 2. Uninstall hyperdata
 ```

--- a/install/onprem/hyperdata/hyperdata/templates/external-hd.yaml
+++ b/install/onprem/hyperdata/hyperdata/templates/external-hd.yaml
@@ -1,0 +1,7 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: hyperdata-external-hd
+spec:
+  type: ExternalName
+  externalName: {{ .Values.customAddon.externalHost }}

--- a/install/onprem/hyperdata/hyperdata/templates/ingress-hd.yaml
+++ b/install/onprem/hyperdata/hyperdata/templates/ingress-hd.yaml
@@ -30,3 +30,9 @@ spec:
          backend:
            serviceName: hyperdata-svc-hd
            servicePort: 8081
+   -  http:
+       paths:
+       - path: {{ .Values.customAddon.path }}
+         backend:
+           serviceName: hyperdata-external-hd
+           servicePort: {{ .Values.customAddon.externalPort }}

--- a/install/onprem/hyperdata/hyperdata/values.yaml
+++ b/install/onprem/hyperdata/hyperdata/values.yaml
@@ -49,7 +49,10 @@ customLogo:
 
 customAddon:
   enabled: false
-  url: 
+  url: https://192.168.179.40:8080/java
+  path: /java
+  externalHost: 192.168.173.48
+  externalPort: 8090
 
 sqlEditor:
   enabled: false


### PR DESCRIPTION
https 환경인 hyperdata에 http인 ibk의 url을 적용/관리하기 위해

생성된 service입니다.

사용되는 변수는 아래와 같습니다.
enable은 용도 그대로
url : FE에서 위젯 호출시 호출하는 주소
path: 외부 서버 url
externalHost: 외부 서버 주소
externalPort: 이부 서버 포트

ex) 
예를 들어 HyperData가 1.1.1.1:8080 이고
위젯 호출하는 외부 서버가 9.9.9.9:7000/widget일 경우

enabled: true
url: https://1.1.1.1:8080/widget
path: /widget
externalHost: 9.9.9.9
externalPort: 7000