### PR TITLE
시스템 모니터링을 위한 prometheus service 설정들

### DIFF
--- a/install/system_management/templates/connect-to-prometheus.yaml
+++ b/install/system_management/templates/connect-to-prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  name: connect-to-prometheus
+spec:
+  type: ExternalName
+  externalName: {{ .Values.prometheus.serviceName }}.{{ .Values.prometheus.namespace }}.svc.cluster.local
+  ports:
+  - port: {{ .Values.prometheus.port }}

--- a/install/system_management/templates/prometheus-ingress.yaml
+++ b/install/system_management/templates/prometheus-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  name: prometheus-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: connect-to-prometheus.yaml
+          servicePort: 9090
+        path: /prometheus(/|$)(.*)
+        pathType: Prefix

--- a/install/system_management/values.yaml
+++ b/install/system_management/values.yaml
@@ -61,17 +61,17 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-#   memory: 128Mi
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+  requests:
+    cpu: "1"
+    memory: "1Gi"
 
 autoscaling:
   enabled: false
@@ -86,6 +86,10 @@ tolerations: []
 
 affinity: {}
 
+prometheus:
+  serviceName: prometheus-kube-prometheus-prometheus
+  namespace: monitoring
+  port: 9090
 ## added setting
 applicationProperties: "application.yml"
 
@@ -206,3 +210,5 @@ customAddon:
   externalPort: 80
 
 imagePullSecrets: ""
+
+


### PR DESCRIPTION
QA 환경에 맞게 values 를 작성해 놨습니다.

실제 배포시에는 고객사 환경을 사용하기 때문에 고객사 환경에 맞게 --set 옵션으로 prometheus와 연동해 주시기 바랍니다.

변경해야 하는 옵션들
prometheus:
  serviceName: prometheus-kube-prometheus-prometheus
  namespace: monitoring
  port: 9090