### PR TITLE
rabbitmq resource 부족으로 인한 down 증상 해결

### DIFF
--- a/install/system_management/rabbitmq/values.yaml
+++ b/install/system_management/rabbitmq/values.yaml
@@ -816,8 +816,8 @@ resources:
   ##    memory: 2Gi
   ##
   limits: 
-    cpu: 250m
-    memory: 256Mi
+    cpu: 500m
+    memory: 512Mi
   ## Examples:
   ## requests:
   ##    cpu: 1000m


### PR DESCRIPTION
resource limit 을 
cpu 250m -> 500m
memory 256Mi -> 512Mi
로 증가시켰습니다.